### PR TITLE
Disable auth when credentials are empty

### DIFF
--- a/src/DI/SimpleHttpAuthExtension.php
+++ b/src/DI/SimpleHttpAuthExtension.php
@@ -14,8 +14,8 @@ class SimpleHttpAuthExtension extends Nette\DI\CompilerExtension
 {
 
 	private $defaults = [
-		'username' => 'admin',
-		'password' => '1234567890',
+		'username' => '',
+		'password' => '',
 		'presenters' => []
 	];
 

--- a/src/SimpleHttpAuth.php
+++ b/src/SimpleHttpAuth.php
@@ -50,6 +50,10 @@ class SimpleHttpAuth extends Nette\DI\CompilerExtension
 		$this->httpResponse = $httpResponse;
 		$this->exit_on_bad_credentials = $exit_on_bad_credentials;
 
+		if (empty($username) && empty($password)) {
+			return;
+		}
+
 		$request = $router->match($httpRequest);
 
 		if (!$request) {

--- a/tests/cases/SimpleHttpAuthTest.phpt
+++ b/tests/cases/SimpleHttpAuthTest.phpt
@@ -8,7 +8,7 @@ use Tester,
 	Nette,
 	Ublaboo;
 
-require __DIR__ . '/../bootstrap.php'; 
+require __DIR__ . '/../bootstrap.php';
 
 final class SimpleHttpAuthTest extends Tester\TestCase
 {
@@ -136,6 +136,31 @@ final class SimpleHttpAuthTest extends Tester\TestCase
 			'admin',
 			'1234567890',
 			['Front:Secured', 'Front:AnotherSecured'],
+			$this->router,
+			$this->request,
+			$this->response,
+			FALSE
+		);
+
+		$response_content = ob_get_clean();
+
+		Assert::null($this->response->header);
+		Assert::null($this->response->code);
+		Assert::same('', $response_content);
+	}
+
+
+	public function testEmptyCredentials()
+	{
+		$this->setupResponse();
+		$this->setupRequest('Front:Homepage', NULL, NULL);
+
+		ob_start();
+
+		$auth = new Ublaboo\SimpleHttpAuth\SimpleHttpAuth(
+			'',
+			'',
+			[],
 			$this->router,
 			$this->request,
 			$this->response,


### PR DESCRIPTION
When we have some testing instances we want protect them with password, but for production/live instance it is important to disable this protection.

Now it is not possible without own fork, this pull can fix that.
